### PR TITLE
[ORC-282] make the call_operation function more robust

### DIFF
--- a/pynso/client.py
+++ b/pynso/client.py
@@ -249,7 +249,11 @@ class NSOClient(object):
         data = self.connection.post(data_store="data", path=path, data=data, params=params)
 
         if data is not None:
-            return data["tailf-ncs:output"]
+            try:
+                if len(data.keys()) == 1 and 'output' in list(data.keys())[0]:
+                    return list(data.values())[0]
+            except KeyError:
+                return data
         return None
 
     def get_rollbacks(self) -> JSON:

--- a/pynso/connection.py
+++ b/pynso/connection.py
@@ -66,7 +66,7 @@ def _handle_json(response: requests.Response) -> Any:
     if response.status_code in [HTTPStatus.NO_CONTENT]:
         return None
     
-    if response.ok and response.text is '':
+    if response.ok and response.text == '':
         return response
 
     try:


### PR DESCRIPTION
client.py - make call_operation function more robust  
  data isn't always returned with the key 'tailf-ncs:output'
connection.py - minor syntax correction